### PR TITLE
Add short pause to prevent the GUI from freezing on certain backends

### DIFF
--- a/rti_stub.py
+++ b/rti_stub.py
@@ -284,6 +284,10 @@ while keepReading:
                 VRTI_err_list.append(VRTI_err)
                 RTI_err   = np.sqrt(np.sum((actualCoord-RTIMaxCoord)**2))
                 RTI_err_list.append(RTI_err)
+
+        # Pause to allow the GUI framework to redraw the screen (required for certain backends)
+        # http://stackoverflow.com/a/12826273/2898712
+        plt.pause(0.0001)
             
     # Save RSS in case next line has missing data.
     prevRSS = rss.copy()


### PR DESCRIPTION
Hi!

On certain backends (namely TkAgg on macOS) the GUI freezes and doesn’t update due to the very fast calls to `draw()`. This can be prevented by inserting a very short pause, that allows the GUI Framework to overtake and redraw the screen. 
See http://stackoverflow.com/a/12826273/2898712
